### PR TITLE
trim template file path

### DIFF
--- a/routes/routes-application.js
+++ b/routes/routes-application.js
@@ -346,7 +346,7 @@ router.post('/show/:foldername/config', spxAuth.CheckLogin, async (req, res) => 
   let command      = req.body.command || "";
   let ftype        = req.body.ftype || "";
   let customscript = req.body.customscript || "";
-  let TemplatePath = path.join(curFolder, template);
+  let TemplatePath = path.join(curFolder, template).trim();
   let ProfileFile  = path.join(config.general.dataroot, showFolder, 'profile.json');
   let profileData = await GetJsonData(ProfileFile) || {}; // or empty
 


### PR DESCRIPTION
Addresses the browsed-file path issue in #20. 

I am new to the codebase. There may be other places this occurs, and this may not be the best place to address the issue, but this change allows adding templates to projects on macOS.