### PR TITLE
fix getSockIndex being case sensitive

### DIFF
--- a/utils/playout_casparCG.js
+++ b/utils/playout_casparCG.js
@@ -211,7 +211,7 @@ module.exports = {
     logger.debug('getSockIndex / Searching for Socket reference for connection "' + SERVERNAME + '"...');
     let serverIndex = "";
     CCGSockets.forEach(function (item, index) {
-      if (global.CCGSockets[index].spxname == SERVERNAME) {
+      if (global.CCGSockets[index].spxname.toLowerCase() == SERVERNAME.toLowerCase()) {
         serverIndex = index;
         logger.debug('getSockIndex found [' + global.CCGSockets[index].spxname + '] so index is [' + serverIndex + '].');
       }


### PR DESCRIPTION
Adding a new server via Configuration -> CasparCG Settings -> CasparCG Server gets automatically turned into ALL_CAPS in the Project Settings -> CasparCG Playout dropdown-menu. This causes issues later on in getSockIndex(SERVERNAME) when comparing the server names if server name wasn't added in ALL_CAPS.

Example: 
- Add new server to configs **Channel_1**, IP_HERE, PORT_HERE
- It shows up as **CHANNEL_1** in Projects/PROJECT_NAME/Project Settings -> CasparCG Playout
- Comparing the names in getSockIndex fails because **Channel_1** != **CHANNEL_1**

Suggested fix:
- Convert both names to lowercase when comparing