### PR TITLE
add rundown/get to get current rundown JSON

### DIFF
--- a/routes/routes-api-v1.js
+++ b/routes/routes-api-v1.js
@@ -69,6 +69,10 @@ router.get('/', function (req, res) {
               "info"    :     "GET Open rundown from project / file."
             },
             {
+              "param"   :     "get",
+              "info"    :     "GET returns current Rundown json"
+            },
+            {
               "param"   :     "focusFirst",
               "info"    :     "GET Move focus to the first item on the rundown."
             },
@@ -323,6 +327,10 @@ router.get('/', function (req, res) {
         logger.error('changeItemID error', error)  ;
         return res.status(409).send('ID not changed');
       }
+});
+
+router.get('/rundown/get', async (req, res) => {
+ res.status(200).send(JSON.stringify(global.rundownData))
 });
 
 


### PR DESCRIPTION
This feature was added to allow better Presets in bitfocus companion
The route will return the current rundown in the JSON format.
This makes it possible to access the ItemID form the JSON and create
Presets so that the User can ignore the ItemIDs in his normal
workflows.