### PR TITLE
Render <br> as HTML in multiline input

### DIFF
--- a/views/view-renderer.handlebars
+++ b/views/view-renderer.handlebars
@@ -257,7 +257,7 @@
                     formattedJsonOut[KEY]=VAL;
                     let e = document.getElementById(iframeID).contentWindow.document.getElementById(KEY);
                     if (e) {
-                        e.innerText=VAL;
+                        e.innerHTML=VAL;
                     }
                 });
                 return JSON.stringify(formattedJsonOut)


### PR DESCRIPTION
Spotted an issue where using a multiline text input renders any newlines are <br> tags. Using `innerHTML` in this case should hopefully correct this issue. 