### PR TITLE
API : Add api entry for focusById

### DIFF
--- a/routes/routes-api-v1.js
+++ b/routes/routes-api-v1.js
@@ -149,6 +149,12 @@ router.get('/', function (req, res) {
             {
               "vers"    :     "1.0",
               "method"  :     "GET",
+              "param"   :     "focusByID/1234567890",
+              "info"    :     "Move focus by ID on the rundown."
+            },
+            {
+              "vers"    :     "1.0",
+              "method"  :     "GET",
               "param"   :     "stopAllLayers",
               "info"    :     "Animate all layers (used by the current rundown) out, but does not clear layers."
             }
@@ -284,6 +290,14 @@ router.get('/', function (req, res) {
     router.get('/rundown/focusLast/', async (req, res) => {
       let dataOut = {};
       dataOut.APIcmd  = 'RundownFocusLast';
+      io.emit('SPXMessage2Controller', dataOut);
+      res.status(200).send('Sent request to controller: ' + JSON.stringify(dataOut));
+    });
+
+    router.get('/rundown/focusByID/:id', async (req, res) => {
+      let dataOut = {};
+      dataOut.APIcmd  = 'RundownFocusByID';
+      dataOut.itemID  = req.params.id;
       io.emit('SPXMessage2Controller', dataOut);
       res.status(200).send('Sent request to controller: ' + JSON.stringify(dataOut));
     });

--- a/static/js/spx_gc.js
+++ b/static/js/spx_gc.js
@@ -105,6 +105,9 @@ socket.on('SPXMessage2Controller', function (data) {
             let lastIndex = document.querySelectorAll('.itemrow').length-1;
             focusRow(lastIndex)
             break;
+        case 'RundownFocusByID':
+            focusRow(getElementByEpoch(data.itemID))
+            break;
 
         case 'RundownStopAll':
             stopAll()


### PR DESCRIPTION
Let user send request to move the focus to a specific id (and show it in the preview).

Example of use :
http://192.168.11.13:5656/api/v1/rundown/focusByID/1651834950798