### PR TITLE
Correct the 'continue' button functionality

### DIFF
--- a/routes/routes-application.js
+++ b/routes/routes-application.js
@@ -624,6 +624,7 @@ router.post('/show/:foldername/config', spxAuth.CheckLogin, async (req, res) => 
         if (!SPXGCTemplateDefinition.out)         {SPXGCTemplateDefinition.out         = "manual"};
         if (!SPXGCTemplateDefinition.dataformat)  {SPXGCTemplateDefinition.dataformat  = "xml"};
         if (!SPXGCTemplateDefinition.uicolor)     {SPXGCTemplateDefinition.uicolor     = "0"};
+        if (!SPXGCTemplateDefinition.steps)       {SPXGCTemplateDefinition.steps       = "1"};
 
         // v.1.0.15 add imported timestamp
         SPXGCTemplateDefinition.imported = String(Date.now()); // epoch. This COULD be used to compare template versions in profile/rundown.


### PR DESCRIPTION
It appears that the 'steps' value is not being defined within the template definition, and so it's not available for inclusion in the playout/rundown item, where it doesn't treat the 'continue' button properly.

This one line change fixes that issue.

Users will need to re-import the template and re-build the playout/rundown items, but at least, from that point on, the 'continue' button will work like it should, from what my testing shows.