### PR TITLE
Make duplicating rundowns safer

### DIFF
--- a/routes/routes-application.js
+++ b/routes/routes-application.js
@@ -1591,12 +1591,13 @@ router.post('/gc/duplicateRundown', spxAuth.CheckLogin, async (req, res) => {
   let filename = req.body.filename;
   let filerefe = path.normalize(path.join(config.general.dataroot,foldname, 'data', filename));
   try {
-    const newFilePath = await spx.duplicateFile(filerefe);
+    const {path, copyNum} = await spx.duplicateFile(filerefe);
 
     // for each template in the duplicated rundown, append "_" to the itemID to avoid conflicts with the old rundown
-    const newRundown = spx.GetJsonData(newFilePath)
-    newRundown?.templates?.forEach((_, index) => newRundown.templates[index].itemID += '_')
-    await spx.writeFile(newFilePath,newRundown);
+    const newRundown = spx.GetJsonData(path)
+    const appendString = `_copy${copyNum || 1}`
+    newRundown?.templates?.forEach((_, index) => newRundown.templates[index].itemID += appendString)
+    await spx.writeFile(path,newRundown);
     
     res.status(200).send('Item duplicated.'); // ok 200 AJAX RESPONSE
   } catch (error) {

--- a/routes/routes-application.js
+++ b/routes/routes-application.js
@@ -1591,7 +1591,13 @@ router.post('/gc/duplicateRundown', spxAuth.CheckLogin, async (req, res) => {
   let filename = req.body.filename;
   let filerefe = path.normalize(path.join(config.general.dataroot,foldname, 'data', filename));
   try {
-    spx.duplicateFile(filerefe, ' copy') ;
+    const newFilePath = await spx.duplicateFile(filerefe);
+
+    // for each template in the duplicated rundown, append "_" to the itemID to avoid conflicts with the old rundown
+    const newRundown = spx.GetJsonData(newFilePath)
+    newRundown?.templates?.forEach((_, index) => newRundown.templates[index].itemID += '_')
+    await spx.writeFile(newFilePath,newRundown);
+    
     res.status(200).send('Item duplicated.'); // ok 200 AJAX RESPONSE
   } catch (error) {
     let errmsg = 'Server error in /gc/duplicateRundown [' + error + ']';

--- a/utils/spx_server_functions.js
+++ b/utils/spx_server_functions.js
@@ -122,19 +122,21 @@ module.exports = {
     const fldrname = path.dirname(fileRefe);
     const extename = path.extname(fileRefe);
     const basename = path.basename(fileRefe, extename);
+    let copyNum
 
     const createCopyPath = (name) => {
       const copyFilePath =  path.normalize(path.join(fldrname, `${name}${extename}`));
 
+      const { groups } = /\((?<existingCopyNum>[0-9]+)\)$/.exec(name) ?? {};
+      const { existingCopyNum } = groups ?? {};      
+      
       if (fs.existsSync(copyFilePath)) {
-        const { groups } = /\((?<copyNum>[0-9]+)\)$/.exec(name) ?? {}
-        const { copyNum } = groups ?? {}
-
         return createCopyPath(
-          copyNum
-          ? name.replace(/^(.*) \(([0-9]+)\)$/, `$1 (${Number(copyNum) + 1})`)
-          : `${name} (1)`)
+          existingCopyNum
+          ? name.replace(/^(.*) \(([0-9]+)\)$/, `$1 (${Number(existingCopyNum) + 1})`)
+          : `${name} (2)`)
       } else {
+        copyNum = existingCopyNum
         return copyFilePath
       }
     }
@@ -146,7 +148,7 @@ module.exports = {
         fs.copyFile(fileRefe, copyPath, (err) => {
           if (err) throw err;
           logger.info('Rundown file ' + fileRefe + ' was copied to ' + copyPath + '.');
-          resolve(copyPath);
+          resolve({path: copyPath, copyNum});
         });
       } catch (error) {
         logger.error('spx.duplicateFile - Error while duplicating: ' + fileRefe + ': ' + error);    


### PR DESCRIPTION
Closes #95 

Makes itemIDs unique when duplicating by appending '_copy${copyNum}' to the end
Uses the same file name system as windows for when copying rundown files to ensure overwrites never happen

It's still possible to have two rundown items have the same name by renaming & deleting copies but this mitigates it substantially