### PR TITLE
feat: Add datatable fType for CSV and Google Sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,9 +726,52 @@ Theoretically all properties are optional, but it's recommended most properties,
 | `checkbox` | `Title` is used as label in UI. _Value_ is "0" or "1" when checked. (Added in 1.0.10) | `[x] Show logo`  |
 | `color` | `Title` is used as label in UI. _Value_ is a valid CSS color string such as `rgb(255,0,0)` (full red) or `rgba(0,0,0,0.33)` (black with 33% opacity). (Added in 1.1.1)<BR>_**Please note**: The Color Picker UI feels a bit flaky, color may need to be selected two or more times for it to register as intended. This may improve in future versions._| `rgba(255,255,255,1.0)`  |
 | `spacer` | Just an empty line to separate out sections. This can be used in very complex templates to visually separate control groups (Added in 1.1.2) | `(no parameters)`|
+| `datatable` | A field for handling tabular data from CSV files or Google Sheets. The `value` can be a URL to a Google Sheet or a path to a local CSV file. | `https://docs.google.com/spreadsheets/d/e/2PACX-1v...` or `/media/csv/data.csv` |
 
 
 > **Note** additional user interface controls may be added in future releases.
+
+### Using the `datatable` fType
+
+The `datatable` fType allows you to display tabular data from a CSV file or a Google Sheet in your templates.
+
+#### Google Sheets
+
+To use a Google Sheet as a data source, you need to publish it to the web as a CSV file.
+
+1.  In your Google Sheet, go to **File > Share > Publish to web**.
+2.  In the **Link** section, select the sheet you want to publish.
+3.  In the **Embed** section, select **Comma-separated values (.csv)**.
+4.  Click **Publish**.
+5.  Copy the generated URL and paste it into the `value` field of your `datatable` in the template definition.
+
+**Example:**
+
+```json
+{
+    "field": "f0",
+    "ftype": "datatable",
+    "title": "My Google Sheet Data",
+    "value": "https://docs.google.com/spreadsheets/d/e/2PACX-1v.../pub?gid=0&single=true&output=csv"
+}
+```
+
+#### Local CSV Files
+
+To use a local CSV file as a data source, you need to place the file in the `ASSETS/csv` folder. Then, in the `datatable` field in the template definition, you can specify the path to the file.
+
+**Example:**
+
+```json
+{
+    "field": "f0",
+    "ftype": "datatable",
+    "title": "My Local CSV Data",
+    "value": "/csv/my_data.csv"
+}
+```
+
+In the controller, you can also select a local CSV file using the file browser that appears when you expand the template item.
 
 ## Anatomy of an example rundown item
 ![anatomy-of-an-item](screenshots/anatomy-of-an-item.png)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^0.30.0",
         "body-parser": "^1.20.3",
         "cors": "^2.8.5",
+        "csv-parser": "^3.0.0",
         "express": "^4.21.2",
         "express-handlebars": "^8.0.1",
         "express-session": "^1.18.1",
@@ -862,6 +863,18 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/csv-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-3.2.0.tgz",
+      "integrity": "sha512-fgKbp+AJbn1h2dcAHKIdKNSSjfp43BZZykXsCjzALjKy80VXQNHPFJ6T9Afwdzoj24aMkq8GwDS7KGcDPpejrA==",
+      "license": "MIT",
+      "bin": {
+        "csv-parser": "bin/csv-parser"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/data-urls": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "axios": "^0.30.0",
     "body-parser": "^1.20.3",
     "cors": "^2.8.5",
+    "csv-parser": "^3.0.0",
     "express": "^4.21.2",
     "express-handlebars": "^8.0.1",
     "express-session": "^1.18.1",

--- a/routes/routes-application.js
+++ b/routes/routes-application.js
@@ -585,6 +585,12 @@ router.post('/show/:foldername/config', spxAuth.CheckLogin, async (req, res) => 
             newExtra.fcall='demo_toggle(this)';
             break;
 
+        case 'datatable':
+            newExtra.description='A new datatable';
+            newExtra.ftype='datatable';
+            newExtra.value='';
+            break;
+
           case 'selectbutton':
             newExtra.description='Selectbutton demo';
             newExtra.ftype='selectbutton';
@@ -759,6 +765,18 @@ router.get('/gc/:foldername/:filename/:mode?', cors(), spxAuth.CheckLogin, async
   
   const fileDataAsJSON = await spx.RemoveFilepathKey(GetJsonData(datafile));
   // fileDataAsJSON = spx.RemoveFilepathKey(fileDataAsJSON); // Added in 1.3.0
+
+  if (fileDataAsJSON && fileDataAsJSON.templates) {
+    for (const template of fileDataAsJSON.templates) {
+      if (template.DataFields) {
+        for (const field of template.DataFields) {
+          if (field.ftype === 'datatable' && field.value) {
+            field.dataTable = await spx.getCsvData(field.value);
+          }
+        }
+      }
+    }
+  }
   
   fileDataAsJSON.project = req.params.foldername; // Added in 1.3.2
   fileDataAsJSON.rundown = req.params.filename; // Added in 1.3.2
@@ -853,201 +871,82 @@ router.post('/gc/:foldername/:filename/', spxAuth.CheckLogin, async (req, res) =
 
     case 'importCSVdata':
       try {
-        // CSV IMPORT function. The source CSV must have been exported via the EXPORT function.
-        let fieldsFound = false; // check at the end
-        logger.verbose('Importing CSV from ' + data.curFolder + '/' + data.importFile + ' to be appended to ' + data.RundownFile);
-        rundownDataJSONobj = await GetJsonData( path.resolve(data.RundownFile) );
-        if (!rundownDataJSONobj.templates) {
-          rundownDataJSONobj.templates = []
-        }
-        // now get the CSV file and start parsing line-by-line
-        let CSVfileData = await GetTextFileData( path.join(data.curFolder, data.importFile ))
-        // console.log('CSV content', CSVfileData.toString());
+        const rundownPath = path.resolve(data.RundownFile);
+        const rundownData = await GetJsonData(rundownPath) || { templates: [] };
+        const csvPath = path.join(data.curFolder, data.importFile);
+        const csvData = await spx.getCsvData(csvPath);
 
-        let startSeconds = String(Date.now());
-
-        let csvLines = CSVfileData.split('\n')
-
-        var t_description
-        var t_playserver
-        var t_playchannel
-        var t_playlayer
-        var t_webplayout
-        var t_out
-        var t_uicolor
-        var t_onair
-        var t_dataformat
-        var t_relpath
-        var t_project
-        var t_rundown
-
-
-        let curLineItems = []
-        var protoFields = [];
-        var protoFtypes = [];
-        var protoTitles = [];
-        var protoValues = [];
-        var dataFiProto = {}; // placeholder obj for fields
-        var templateTmp = []; // placeholder arr for objects
-        var fieldIndex = 0; // iterate 
-
-
-        // First we get METADATA (another lines forEach for content afterwards)
-        csvLines.forEach((line,lineindex) => {
-          if (line.trim()==='') { return; }
-          curLineItems = line.split(';')
-          // console.log('Line ' + lineindex, curLineItems);
-          switch ( curLineItems[0].trim() ){
-            case '# description #':
-              t_description = curLineItems[1].trim();
-              break;
-
-            case '# playserver #':
-              t_playserver = curLineItems[1].trim();
-              break;
-
-            case '# playchannel #':
-              t_playchannel = curLineItems[1].trim();
-              break;
-
-            case '# playlayer #':
-              t_playlayer = curLineItems[1].trim();
-              break;
-
-            case '# webplayout #':
-              t_webplayout = curLineItems[1].trim();
-              break;
-
-            case '# out #':
-              t_out = curLineItems[1].trim();
-              break;
-
-            case '# uicolor #':
-              t_uicolor = curLineItems[1].trim();
-              break;
-
-            case '# onair #':
-              t_onair = curLineItems[1].trim();
-              break;
-
-            case '# dataformat #':
-              t_dataformat = curLineItems[1].trim();
-              break;
-
-            case '# relpath #':
-              t_relpath = curLineItems[1].trim();
-              break;
-
-            case '# project #':
-              t_project = curLineItems[1].trim();
-              break;
-
-            case '# rundown #':
-              t_rundown = curLineItems[1].trim();
-              break;
-
-
-            case '# FieldUUIDs #':
-              // this line carries f-field ids (f0, f1, etc)
-              // and will generate required objects
-              fieldsFound = true;
-              for (let uuidindex = 1; uuidindex < curLineItems.length-1; uuidindex++) {
-                protoFields.push(curLineItems[uuidindex].trim());
+        if (data.templateIndex) {
+          // New method: Add CSV data to a specific template's datatable field
+          const templateIndex = parseInt(data.templateIndex, 10);
+          const itemID = data.itemID;
+          let success = false;
+          for (const template of rundownData.templates) {
+            if (template.itemID === itemID) {
+              for (const field of template.DataFields) {
+                if (field.ftype === 'datatable') {
+                  field.value = csvPath;
+                  field.dataTable = csvData;
+                  success = true;
+                  break;
+                }
               }
-              break;
-
-            case '# FieldTypes #':
-              for (let typeindex = 1; typeindex < curLineItems.length-1; typeindex++) {
-                let thisFieldType = curLineItems[typeindex].trim()
-                protoFtypes.push(thisFieldType)
-              }
-              break;
-
-            case '# FieldTitls #':
-              for (let titindex = 1; titindex < curLineItems.length-1; titindex++) {
-                protoTitles.push(curLineItems[titindex].trim())
-              }
-              break;
-          } // switch line type
-        }); // for each line METADATA done
-
-
-        // Then iterate all CONTENT LINES and append template to OBJ array
-        var templateData
-        csvLines.forEach((line,loopIndex) => {
-          if (line.trim()==='') { return; } // empty line
-          curLineItems = line.split(';')
-          templateData = {}
-          templateData.DataFields = []
-
-          if (line.startsWith('# ID:')) {
-
-            fieldIndex++; // template counter for GUI message
-
-            for (let index = 1; index < curLineItems.length-1; index++) {
-              protoValues.push(curLineItems[index].trim())
             }
-
-            // generate ID
-            if (line.startsWith('# ID:auto')) {
-              // generate EPOCH
-              templateData.itemID = startSeconds + loopIndex
-            } else {
-              // use the given value
-              templateData.itemID = curLineItems[0].trim().replace('# ID:', '').trim()
-            }
-
-            templateData.description  = t_description
-            templateData.playserver   = t_playserver
-            templateData.playchannel  = t_playchannel
-            templateData.playlayer    = t_playlayer
-            templateData.webplayout   = t_webplayout
-            templateData.out          = t_out
-            templateData.uicolor      = t_uicolor
-            templateData.onair        = t_onair
-            templateData.dataformat   = t_dataformat
-            templateData.relpath      = t_relpath
-
-            // Append warning
-            templateData.DataFields.push({
-                ftype: "instruction",
-                value: "⚠ WARNING: This item was generated with CSV import and typically is not intended for manual editing. Please use the original template for manual input."
-              });
-
-            // Then iterate all fields and assing values
-            for (let i = 0; i < protoFields.length; i++) {
-              dataFiProto={}            
-              dataFiProto.field = protoFields[i]
-              if (protoFtypes[i]=='textarea') {
-                dataFiProto.ftype = 'textarea'  // for multiline texts
-              } else {
-                dataFiProto.ftype = 'textfield' // protoFtypes[i] !forced!
-              }
-              // dataFiProto.ftype = "textfield" // protoFtypes[i] !forced!
-              dataFiProto.title = protoTitles[i]
-              dataFiProto.value = curLineItems[i+1].replace(/<BR>/g,'\n') // add newlines back
-              templateData.DataFields.push(dataFiProto);
-            }
-
-            rundownDataJSONobj.templates.push(templateData)
-          } // content line process ended 
-        });
-
-        // saving new items to disk
-        rundownDataJSONobj.project = t_project; // Added in 1.3.2
-        rundownDataJSONobj.rundown = t_rundown; // Added in 1.3.2
-        global.rundownData = rundownDataJSONobj;
-        await SaveRundownDataToDisc(data.RundownFile) // Bug fixed in 1.3.2
-        if (fieldsFound) {
-          res.redirect('/gc/' + data.foldername + '/' + data.filebasename + '?msg=Added ' + fieldIndex + ' templates.'); 
-          break;
+            if(success) break;
+          }
+          if (!success) {
+            return res.redirect(`/gc/${data.foldername}/${data.filebasename}?msg=datatableFieldNotFound`);
+          }
         } else {
-          res.redirect('/gc/' + data.foldername + '/' + data.filebasename + '?msg=invalidCSV'); 
+          // Legacy method: Append new templates from CSV
+          const templateProto = csvData.find(row => row['# FieldUUIDs #']);
+          if (!templateProto) {
+            return res.redirect(`/gc/${data.foldername}/${data.filebasename}?msg=invalidCSV`);
+          }
+          const protoFields = Object.keys(templateProto).filter(key => key.startsWith('f'));
+          const newTemplates = csvData.map((row, index) => {
+            if (row['# ID:']) {
+              const newTemplate = {
+                itemID: row['# ID:'] === 'auto' ? `${Date.now()}${index}` : row['# ID:'],
+                description: row['# description #'] || '',
+                playserver: row['# playserver #'] || '-',
+                playchannel: row['# playchannel #'] || '1',
+                playlayer: row['# playlayer #'] || '20',
+                webplayout: row['# webplayout #'] || '20',
+                out: row['# out #'] || 'manual',
+                uicolor: row['# uicolor #'] || '0',
+                onair: 'false',
+                dataformat: row['# dataformat #'] || 'json',
+                relpath: row['# relpath #'] || '',
+                DataFields: [
+                  {
+                    ftype: 'instruction',
+                    value: '⚠ WARNING: This item was generated with CSV import and typically is not intended for manual editing. Please use the original template for manual input.'
+                  },
+                  ...protoFields.map(field => ({
+                    field,
+                    ftype: row['# FieldTypes #'] && row['# FieldTypes #'][field] === 'textarea' ? 'textarea' : 'textfield',
+                    title: row['# FieldTitls #'] ? row['# FieldTitls #'][field] : '',
+                    value: row[field] ? row[field].replace(/<BR>/g, '\n') : ''
+                  }))
+                ]
+              };
+              return newTemplate;
+            }
+            return null;
+          }).filter(Boolean);
+          rundownData.templates.push(...newTemplates);
         }
+
+        rundownData.project = data.foldername;
+        rundownData.rundown = data.filebasename;
+        global.rundownData = rundownData;
+        await SaveRundownDataToDisc(rundownPath);
+        res.redirect(`/gc/${data.foldername}/${data.filebasename}?msg=Added ${csvData.length} templates.`);
       } catch (error) {
         logger.error('importCSVdata Error: ', error);
+        res.redirect(`/gc/${data.foldername}/${data.filebasename}?msg=importError`);
       }
-
       break;
 
     case 'addAllItemsToRundown': 

--- a/static/js/spx_gc.js
+++ b/static/js/spx_gc.js
@@ -2264,7 +2264,13 @@ function saveTemplateItemChangesByElement(itemrow) {
             {
                 let updatedObj = {}
                 updatedObj.field = input.getAttribute('data-update');
-                updatedObj.value = input.value;
+                switch (input.getAttribute('data-ftype')) {
+                    case 'datatable':
+                        updatedObj.value = input.value;
+                        break;
+                    default:
+                        updatedObj.value = input.value;
+                }
                 if (input.type === 'checkbox') {
                     if (input.checked) {
                         updatedObj.value = '1';
@@ -2761,8 +2767,85 @@ function ToggleExpand(rowelement='') {
                 }
             AppState('EDITING');
         }
+
+        const itemID = rowelement.getAttribute('data-spx-epoch');
+        const templateData = JSON.parse(decodeURI(rowelement.querySelector('input[name="RundownItem[DataFields]"]').value));
+        templateData.forEach(field => {
+            if (field.ftype === 'datatable') {
+                const dataTableUI = createDataTableUI(field, itemID);
+                Expanded.querySelector('.expandedcontent').appendChild(dataTableUI);
+            }
+        });
     }
 } // ToggleExpand
+
+function createDataTableUI(field, itemID) {
+    const container = document.createElement('div');
+    container.classList.add('datatable-container');
+
+    const label = document.createElement('label');
+    label.textContent = field.title || 'Data Source';
+    container.appendChild(label);
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = field.value || '';
+    input.setAttribute('data-role', 'userEditable');
+    input.setAttribute('data-update', field.field);
+    input.setAttribute('data-ftype', 'datatable');
+    input.placeholder = 'Enter Google Sheet URL or select a local CSV file';
+    container.appendChild(input);
+
+    const fileInput = document.createElement('input');
+    fileInput.type = 'file';
+    fileInput.accept = '.csv';
+    fileInput.style.display = 'none';
+    fileInput.addEventListener('change', (event) => {
+        const file = event.target.files[0];
+        if (file) {
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                const csvData = e.target.result;
+                const data = {
+                    command: 'importCSVdata',
+                    RundownFile: document.getElementById('datafile').value,
+                    curFolder: 'ASSETS/csv',
+                    importFile: file.name,
+                    templateIndex: getIndexOfRowItem(getElementByEpoch(itemID)),
+                    itemID: itemID,
+                    csvData: csvData
+                };
+                post('', data, 'post');
+            };
+            reader.readAsText(file);
+        }
+    });
+    container.appendChild(fileInput);
+
+    const fileButton = document.createElement('button');
+    fileButton.textContent = 'Select Local CSV';
+    fileButton.addEventListener('click', () => {
+        fileInput.click();
+    });
+    container.appendChild(fileButton);
+
+    const importButton = document.createElement('button');
+    importButton.textContent = 'Import from URL';
+    importButton.addEventListener('click', () => {
+        const data = {
+            command: 'importCSVdata',
+            RundownFile: document.getElementById('datafile').value,
+            curFolder: '',
+            importFile: input.value,
+            templateIndex: getIndexOfRowItem(getElementByEpoch(itemID)),
+            itemID: itemID
+        };
+        post('', data, 'post');
+    });
+    container.appendChild(importButton);
+
+    return container;
+}
 
 function updateItem(itemrow) {
     // request ..... rundown template index
@@ -2790,7 +2873,11 @@ function updateItem(itemrow) {
     CurrentDomFields.forEach((item,index) => {
       let formField={};
       formField.field = item.getAttribute('data-update');
-      formField.value = item.value;
+      if (item.getAttribute('data-ftype') === 'datatable') {
+        formField.value = item.value;
+      } else {
+        formField.value = item.value;
+      }
       if (item.type === 'checkbox') {
         if (item.checked) { 
             formField.value = '1'

--- a/utils/spx_server_functions.js
+++ b/utils/spx_server_functions.js
@@ -11,6 +11,7 @@ const glob = require("glob");
 const ip = require('ip')
 const axios = require('axios')
 const http = require('http');
+const csv = require('csv-parser');
 // ----------------------------------------- good until here
 // const { config } = require('process');
 
@@ -244,6 +245,11 @@ module.exports = {
                 html += '<span id="datapreview_' + fieldIndex + '">' + this.shortifyString(fValu) + '</span>';
                 Counter++;
                 break;
+
+              case "datatable":
+                html += '<span id="datapreview_' + fieldIndex + '">DATATABLE: ' + this.shortifyString(this.fileNameFromPath(fValu)) + '</span>';
+                Counter++;
+                break;
               
               default:
                 skip = true
@@ -330,6 +336,47 @@ module.exports = {
       return (error);
     }
   }, // GetJsonData ended
+
+  getCsvData: async function (fileref) {
+    // require ..... Full file path or URL
+    // returns ..... File contents as a JSON object
+    const results = [];
+    return new Promise((resolve, reject) => {
+      if (fileref.startsWith('http')) {
+        // Handle URL
+        axios.get(fileref, { responseType: 'stream' })
+          .then(response => {
+            response.data
+              .pipe(csv())
+              .on('data', (data) => results.push(data))
+              .on('end', () => {
+                resolve(results);
+              });
+          })
+          .catch(error => {
+            logger.error('ERROR in spx.getCsvData() from URL: ' + error);
+            reject(error);
+          });
+      } else {
+        // Handle local file
+        if (!fs.existsSync(fileref)) {
+          logger.warn('Tried to read CSV from non-existing file ' + fileref);
+          resolve([]); // Return empty array if file does not exist
+          return;
+        }
+        fs.createReadStream(fileref)
+          .pipe(csv())
+          .on('data', (data) => results.push(data))
+          .on('end', () => {
+            resolve(results);
+          })
+          .on('error', (error) => {
+            logger.error('ERROR in spx.getCsvData() from file: ' + error);
+            reject(error);
+          });
+      }
+    });
+  },
 
   getJSONFileList: function (FOLDER) {
     try {
@@ -568,11 +615,11 @@ module.exports = {
             let fil = filter.toUpperCase();
             let fir = path.basename(curPath).charAt(0); // first character (dot files) Added in 1.1.0
 
-            if (fil === 'HTM' && ext ==".HTM" || ext ==".HTML" && fir != '.') {
+            if (fil === 'HTM' && (ext == ".HTM" || ext == ".HTML") && fir != '.') {
               data.fileArr.push(path.basename(curPath));
             }
 
-            if (fil === 'CSV' && ext ==".CSV" && fir != '.') {
+            if (fil === 'CSV' && ext == ".CSV" && fir != '.') {
               data.fileArr.push(path.basename(curPath));
             }
           }

--- a/views/partials/datatable.handlebars
+++ b/views/partials/datatable.handlebars
@@ -1,0 +1,44 @@
+<style>
+    .datatable-container {
+        width: 100%;
+        overflow-x: auto;
+    }
+    .datatable {
+        width: 100%;
+        border-collapse: collapse;
+    }
+    .datatable th, .datatable td {
+        border: 1px solid #ddd;
+        padding: 8px;
+    }
+    .datatable tr:nth-child(even){background-color: #f2f2f2;}
+    .datatable tr:hover {background-color: #ddd;}
+    .datatable th {
+        padding-top: 12px;
+        padding-bottom: 12px;
+        text-align: left;
+        background-color: #4CAF50;
+        color: white;
+    }
+</style>
+
+<div class="datatable-container">
+    <table class="datatable">
+        <thead>
+            <tr>
+                {{#each headers}}
+                    <th>{{this}}</th>
+                {{/each}}
+            </tr>
+        </thead>
+        <tbody>
+            {{#each rows}}
+                <tr>
+                    {{#each this}}
+                        <td>{{this}}</td>
+                    {{/each}}
+                </tr>
+            {{/each}}
+        </tbody>
+    </table>
+</div>

--- a/views/view-renderer.handlebars
+++ b/views/view-renderer.handlebars
@@ -649,7 +649,10 @@
         <iframe class="frame" allow="autoplay" id="layer18" style="z-index: 118;" src="about:blank"></iframe>
         <iframe class="frame" allow="autoplay" id="layer19" style="z-index: 119;" src="about:blank"></iframe>
         <iframe class="frame" allow="autoplay" id="layer20" style="z-index: 120;" src="about:blank"></iframe>
-    </div><div class="debugMessage" id="debugMessage" style="opacity:0; position: absolute; z-index:1000;"></div>
-
+    </div>
+    <div class="debugMessage" id="debugMessage" style="opacity:0; position: absolute; z-index:1000;"></div>
+    {{#if dataTable}}
+        {{> datatable dataTable}}
+    {{/if}}
 </body>
 </html>


### PR DESCRIPTION
This commit introduces a new `datatable` fType that allows for the rendering of tabular data from CSV files or Google Sheets within templates.

Key changes:
- Modified `utils/spx_server_functions.js` to handle the new `datatable` fType.
- Modified `routes/routes-application.js` to handle the new `datatable` fType.
- Modified `static/js/spx_gc.js` to handle the new `datatable` fType.
- Created a new Handlebars partial for rendering the `datatable`.
- Updated the documentation to include information about the new `datatable` fType.