### PR TITLE
Fix update not working bug

### DIFF
--- a/views/view-renderer.handlebars
+++ b/views/view-renderer.handlebars
@@ -491,7 +491,7 @@
                     break;
 
                 case 'updateTemplate':
-                    projectFormat = incomingData.projectFormat || 'OGRAF'; // default value
+                    projectFormat = incomingData.projectFormat || 'SPX'; // default value
                     LayerNro = validateLayerNro(data.webplayout);
                     setTimeout(function(){ updateLayer(data.webplayout, data.fields, projectFormat); }, 10);
                     break;


### PR DESCRIPTION
Currently, clicking the update button in SPX Solo v.1.4.0 does nothing as it does not update the template.  This bug is not present in v.1.3.0.

The bug is fixed by setting the default value of `projectFormat` from `'OGRAF'` to `'SPX'`.  Prior to this change, it will call `updateItem()`, but it will result into an error since `document.getElementById('datafile')` is `null`.  Updating in SPX format doesn't need to call `updateItem()` as it will call the template's own update handler function, which fixes the problem.

Additionally, I noticed through observation that the default value of `projectFormat` in `case 'nextTemplate'` and `case 'stopTemplate'` is set to `'SPX'`, so I also set the default value in `case 'updateTemplate'` to `'SPX'`, and the problem is fixed.